### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ Criamos um arquimo .gitignore
 Já existe um arquivo pronto no site "gitignore.io"
 
 Subindo para o Github:
-git init 
-dit add .
+git init
+git add .
 git commit -m "nome do projeto" ex: alura space
 Na pagina do Github copiar o endereço do "ssh".
 


### PR DESCRIPTION
## Summary
- fix command typo in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f46f6936c8329b2d90045357e4edd