### PR TITLE
Fix import typo in settings

### DIFF
--- a/setup/settings.py
+++ b/setup/settings.py
@@ -10,7 +10,8 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/4.1/ref/settings/
 """
 
-from pathlib import Path, os
+from pathlib import Path
+import os
 from dotenv import load_dotenv
 load_dotenv()
 


### PR DESCRIPTION
## Summary
- fix import bug in `setup/settings.py` so Django settings module imports `Path` correctly

## Testing
- `python -m py_compile setup/settings.py`
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_683f462ae978832996267f08d23b7a62